### PR TITLE
hack/olm-registry: pko updates

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -28,7 +28,7 @@ objects:
   spec:
     clusterDeploymentSelector:
       matchLabels:
-        osde2eInactive: 'true'
+        api.openshift.com/name: osde2e-example-1
     resourceApplyMode: Upsert
     resources:
     - apiVersion: v1

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 parameters:
 - name: CHANNEL

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -29,7 +29,7 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         osde2eInactive: 'true'
-    resourceApplyMode: Sync
+    resourceApplyMode: Upsert
     resources:
     - apiVersion: v1
       kind: Namespace


### PR DESCRIPTION
- change resourceApplyMode from Sync to Upsert which will remove the resources tracked for deletion from the ClusterSync object.
- update apiVersion to groupified version
- change the matchlabel to match a clustername for ease of deployment

Signed-off-by: Brady Pratt <bpratt@redhat.com>
