### PR TITLE
config: set EnableOLMSkipRange to true

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,7 @@
 package config
 
 const (
-	OperatorName      string = "osd-example-operator"
-	OperatorNamespace string = "openshift-osd-example-operator"
+	OperatorName       string = "osd-example-operator"
+	OperatorNamespace  string = "openshift-osd-example-operator"
+	EnableOLMSkipRange string = "true"
 )


### PR DESCRIPTION
boilerplate supports producing single version bundles which will allow us to jump versions when upgradging, skipping bad versions without having to prune from the upgrade graph.

A new annotation will be added to the CSV like below, and the bundle image will contain only one version

https://github.com/openshift/boilerplate/blob/f8b6c332db4579b4869fcd98d16c762e63db9211/boilerplate/openshift/golang-osd-operator/csv-generate/common-generate-operator-bundle.py#L397-L400