### PR TITLE
osde2e: add Containerfile specific for konflux

### DIFF
--- a/osde2e/Containerfile.konflux
+++ b/osde2e/Containerfile.konflux
@@ -1,0 +1,8 @@
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.22 AS builder
+WORKDIR /go/src/github.com/openshift/osd-example-operator/
+COPY . .
+RUN  CGO_ENABLED=0 GOFLAGS="-mod=mod" go test ./osde2e -v -c --tags=osde2e -o /harness.test
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+COPY --from=builder ./harness.test harness.test
+ENTRYPOINT [ "/harness.test" ]


### PR DESCRIPTION
the base image we use in osde2e/Dockerfile does not meet the app-interface-standard EnterpriseContractPolicy. Add a new copy of the original file but with a different base image.

https://github.com/openshift/hypershift/blob/07adf9be46647b59a1f53f4474559f41750596a3/Containerfile.operator#L1

https://gitlab.cee.redhat.com/releng/konflux-release-data/-/blob/main/config/common/service/EnterpriseContractPolicy/app-interface-standard.yaml