### PR TITLE
.tekton/bundle*: don't skip-checks

### DIFF
--- a/.tekton/bundle-pull-request.yaml
+++ b/.tekton/bundle-pull-request.yaml
@@ -95,7 +95,7 @@ spec:
       description: Force rebuild image
       name: rebuild
       type: string
-    - default: "true"
+    - default: "false"
       description: Skip checks against built image
       name: skip-checks
       type: string

--- a/.tekton/bundle-push.yaml
+++ b/.tekton/bundle-push.yaml
@@ -92,7 +92,7 @@ spec:
       description: Force rebuild image
       name: rebuild
       type: string
-    - default: "true"
+    - default: "false"
       description: Skip checks against built image
       name: skip-checks
       type: string


### PR DESCRIPTION
nevermind, we can't skip it still fails (what is the point of the skip-checks param?)