### PR TITLE
set Konflux flag to true to pick allowed image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 include boilerplate/generated-includes.mk
 
+export KONFLUX_BUILDS=true
 
 .PHONY: boilerplate-update
 boilerplate-update:


### PR DESCRIPTION
set Konflux flag to true to pick allowed image

will fix error:
`[registry.ci.openshift.org/openshift/release@​sha256:1e5b114845d85e239982538f8943a28be9d12e01349ad8cff30780208cfe6475](http://registry.ci.openshift.org/openshift/release@%E2%80%8Bsha256:1e5b114845d85e239982538f8943a28be9d12e01349ad8cff30780208cfe6475)` is from a disallowed registry.