### PR TITLE
shorten job name per k8s limits

### DIFF
--- a/test/e2e/e2e-template.yml
+++ b/test/e2e/e2e-template.yml
@@ -38,7 +38,7 @@ objects:
   - apiVersion: batch/v1
     kind: Job
     metadata:
-      name: osde2e-osd-example-operator-${IMAGE_TAG}-${JOBID}
+      name: osde2e-oeo-${IMAGE_TAG}-${JOBID}
     spec:
       backoffLimit: 0
       template:


### PR DESCRIPTION
shorten job name per k8s limits
- tekton job fails to run with `"osde2e-osd-example-operator-361e45010aa17e49f19a4d68ef3259de48f0e32a-ek73583": must be no more than 63 characters` 
- follow up with change to boilerplate to shorten this name in e2e-template as well