### PR TITLE
SDCICD-1658: enable llm analysis for OEO

### DIFF
--- a/test/e2e/e2e-template.yml
+++ b/test/e2e/e2e-template.yml
@@ -54,6 +54,7 @@ objects:
                 - --only-health-check-nodes
                 - --skip-destroy-cluster
                 - --skip-must-gather
+                - --enable-llm-analysis
                 - --configs
                 - ${OSDE2E_CONFIGS}
               securityContext:
@@ -85,4 +86,6 @@ objects:
                 - name: USE_EXISTING_CLUSTER
                   value: ${USE_EXISTING_CLUSTER}
                 - name: CAD_PAGERDUTY_ROUTING_KEY
-                  value: ${CAD_PAGERDUTY_ROUTING_KEY}                 
+                  value: ${CAD_PAGERDUTY_ROUTING_KEY}
+                - name: GEMINI_API_KEY
+                  value: ${GEMINI_API_KEY}


### PR DESCRIPTION
- `--enable-llm-analysis` This flag activates LLM analysis
- `GEMINI_API_KEY`: This is the API key used to authenticate and interact with the Gemini LLM