### PR TITLE
Add Tekton Results integration for osde2e

### DIFF
--- a/test/e2e/TEKTON-RESULTS-README.md
+++ b/test/e2e/TEKTON-RESULTS-README.md
@@ -1,0 +1,243 @@
+# Tekton Results Integration for OSDE2E Tests
+
+Complete guide for integrating Tekton Results with osde2e testing to enable structured test result collection and enhanced observability.
+
+## 📦 What's Included
+
+This integration adds three core files that replace the traditional Kubernetes Job with Tekton Pipelines:
+
+1. **`osde2e-tekton-task.yml`** (12KB) - Multi-step Task with structured result collection
+2. **`osde2e-pipeline.yml`** (4.9KB) - Pipeline orchestration
+3. **`e2e-tekton-template.yml`** (6.3KB) - OpenShift Template (referenced by app-interface)
+
+## 🔄 Required Changes in app-interface
+
+Only **2 changes** needed in `osde2e-focus-test.yaml`:
+
+### Change 1: Update Template Path
+```yaml
+resourceTemplates:
+- name: saas-oeo-e2e-test
+  url: https://github.com/openshift/osd-example-operator
+  path: /test/e2e/e2e-tekton-template.yml  # Changed from e2e-template.yml
+```
+
+### Change 2: Update Resource Types
+```yaml
+managedResourceTypes:
+- PipelineRun.tekton.dev              # Changed from: Job
+- ServiceAccount
+- Role.rbac.authorization.k8s.io      # Changed from: ClusterRole
+- RoleBinding.rbac.authorization.k8s.io  # Changed from: ClusterRoleBinding
+- PersistentVolumeClaim               # New: for workspace storage
+```
+
+**Everything else unchanged**: parameters, credentials, test logic, promotion channels, Slack notifications.
+
+## ✅ Key Benefits
+
+| Feature | Job (Current) | Tekton + Results (New) |
+|---------|--------------|------------------------|
+| **Result Storage** | Pod logs (temporary) | Structured Results (persistent) |
+| **Observability** | Single log stream | Multi-step visibility |
+| **Result Format** | Plain text | Structured (status, logs, summary, JUnit) |
+| **Historical Query** | Not supported | Supported (via Results API) |
+| **UI** | Basic Pod logs | Enhanced (Pipeline graph, Results panel) |
+
+### Structured Results Captured
+- **test-status**: PASS/FAIL status
+- **test-logs**: Complete test execution logs
+- **test-summary**: Test summary (timing, config, status)
+- **test-results**: JUnit XML format
+
+## 🚀 Quick Start
+
+### 1. Deploy Tekton Resources
+```bash
+cd test/e2e
+
+# Deploy Task and Pipeline
+oc apply -f osde2e-tekton-task.yml -n <namespace>
+oc apply -f osde2e-pipeline.yml -n <namespace>
+
+# Verify deployment
+oc get task osde2e-test-task -n <namespace>
+oc get pipeline osde2e-test-pipeline -n <namespace>
+```
+
+### 2. Run a Test
+```bash
+# Using the template (app-interface style)
+oc process -f e2e-tekton-template.yml \
+  -p OSDE2E_CONFIGS="rosa,sts,int,ad-hoc-image" \
+  -p TEST_IMAGE="quay.io/redhat-services-prod/oeo-cicada-tenant/osd-example-operator-e2e" \
+  -p IMAGE_TAG="latest" \
+  -p CLOUD_PROVIDER_REGION="us-east-1" \
+  -p NAMESPACE="<namespace>" \
+  | oc apply -f -
+```
+
+### 3. View Results
+```bash
+# Get latest PipelineRun
+PIPELINERUN=$(oc get pipelinerun -n <namespace> --sort-by=.metadata.creationTimestamp -o jsonpath='{.items[-1].metadata.name}')
+
+# View Results
+oc get pipelinerun $PIPELINERUN -n <namespace> -o jsonpath='{.status.results}' | jq
+
+# Expected output:
+# [{"name": "final-test-status", "value": "PASS"}]
+
+# View detailed logs
+tkn pipelinerun logs $PIPELINERUN -f -n <namespace>
+```
+
+## 📖 Complete Documentation
+
+For detailed information, see:
+- **Complete Verification Guide (Chinese)**: [TEKTON-RESULTS-VERIFICATION.md](./TEKTON-RESULTS-VERIFICATION.md)
+  - Prerequisites and environment checks
+  - How Tekton Results works (architecture diagram)
+  - Step-by-step deployment instructions
+  - Multiple methods to view and verify Results
+  - OpenShift Console navigation guide
+  - Tekton Results API usage
+  - Troubleshooting common issues
+  - Complete verification checklist
+
+## 🔍 Quick Verification
+
+### Check Results in PipelineRun
+```bash
+# View PipelineRun status
+oc get pipelinerun $PIPELINERUN -n <namespace>
+
+# View Results
+oc get pipelinerun $PIPELINERUN -n <namespace> -o jsonpath='{.status.results}' | jq
+
+# View TaskRun Results (detailed)
+TASKRUN=$(oc get taskrun -n <namespace> -l tekton.dev/pipelineRun=$PIPELINERUN -o jsonpath='{.items[0].metadata.name}')
+oc get taskrun $TASKRUN -n <namespace> -o jsonpath='{.status.results}' | jq
+
+# Expected: test-status, test-logs, test-summary, test-results
+```
+
+### View in OpenShift Console
+```
+1. Navigate to: Pipelines → PipelineRuns
+2. Click on your PipelineRun
+3. See Results panel showing test-status
+4. Click "Logs" tab to view step-by-step execution
+```
+
+## 🐛 Troubleshooting
+
+### PipelineRun Stuck in Pending
+```bash
+# Check events
+oc describe pipelinerun $PIPELINERUN -n <namespace> | grep -A 10 Events
+
+# Common causes: PVC creation, ServiceAccount permissions, Task/Pipeline missing
+```
+
+### No Results Visible
+```bash
+# Check TaskRun logs
+tkn taskrun logs $TASKRUN -n <namespace>
+
+# Verify Results annotations
+oc get pipelinerun $PIPELINERUN -n <namespace> -o jsonpath='{.metadata.annotations}' | grep results
+```
+
+### Results Empty or Incomplete
+```bash
+# Tekton Results have a 4KB limit per result
+# For large logs, only summary is stored in Results
+# Complete logs available via: tkn pipelinerun logs
+```
+
+## 📊 Migration Path
+
+### Phase 1: osd-example-operator PR (Current)
+- Add 3 new files to repository
+- No changes to existing tests
+
+### Phase 2: app-interface PR (After merge)
+- Update 2 fields in osde2e-focus-test.yaml
+- Test in int01 → stage02 → production
+
+### Rollback
+If issues occur, revert the app-interface path change:
+```yaml
+path: /test/e2e/e2e-template.yml  # Back to Job template
+```
+
+## 📊 How It Works
+
+```
+┌─────────────────────────────────────────┐
+│ app-interface SaaS File                 │
+│  path: /test/e2e/e2e-tekton-template.yml│
+└──────────────────┬──────────────────────┘
+                   │
+                   ▼
+┌─────────────────────────────────────────┐
+│ Template Creates:                       │
+│  - PipelineRun (with Results annotations)│
+│  - ServiceAccount                        │
+│  - Role/RoleBinding                      │
+│  - PersistentVolumeClaim                 │
+└──────────────────┬──────────────────────┘
+                   │
+                   ▼
+┌─────────────────────────────────────────┐
+│ Pipeline Executes:                      │
+│  - osde2e-test-task                     │
+│    1. Fix permissions                    │
+│    2. Setup environment                  │
+│    3. Run osde2e tests                   │
+│    4. Collect results (structured)       │
+└──────────────────┬──────────────────────┘
+                   │
+                   ▼
+┌─────────────────────────────────────────┐
+│ Results Stored:                         │
+│  - TaskRun.status.results[] (4 results) │
+│  - PipelineRun.status.results[] (1 result)│
+│  - (Optional) Results API database       │
+└─────────────────────────────────────────┘
+```
+
+## 📊 Success Indicators
+
+When you see this output, integration is successful:
+
+```bash
+$ oc get pipelinerun $PIPELINERUN -n <namespace>
+NAME                          SUCCEEDED   REASON      STARTTIME   COMPLETIONTIME
+osde2e-...-1730300000        True        Succeeded   5m          2m
+
+$ oc get pipelinerun $PIPELINERUN -n <namespace> -o jsonpath='{.status.results}' | jq
+[
+  {
+    "name": "final-test-status",
+    "value": "PASS"
+  }
+]
+
+$ oc get taskrun $TASKRUN -n <namespace> -o jsonpath='{.status.results[*].name}'
+test-status test-logs test-summary test-results
+```
+
+## 🔗 Additional Resources
+
+- [Tekton Results Official Docs](https://tekton.dev/docs/pipelines/results/)
+- [OpenShift Pipelines Docs](https://docs.openshift.com/pipelines/)
+- [Complete Verification Guide (Chinese)](./TEKTON-RESULTS-VERIFICATION.md)
+
+---
+
+**Need Help?**
+- See [TEKTON-RESULTS-VERIFICATION.md](./TEKTON-RESULTS-VERIFICATION.md) for detailed step-by-step guide
+- Contact via JIRA: SDCICD-1672
+

--- a/test/e2e/e2e-tekton-template.yml
+++ b/test/e2e/e2e-tekton-template.yml
@@ -1,0 +1,201 @@
+# OpenShift Template for OSDE2E Testing with Tekton Pipeline
+# This template creates a PipelineRun instead of a Job for enhanced observability
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: osde2e-focused-tests-tekton
+  labels:
+    app: osde2e
+    component: testing
+    version: tekton-v1
+  annotations:
+    description: "OSDE2E focused tests using Tekton Pipeline for enhanced observability"
+    iconClass: "icon-openshift"
+    tags: "osde2e,testing,tekton,pipeline"
+    openshift.io/display-name: "OSDE2E Tekton Tests"
+    openshift.io/documentation-url: "https://github.com/openshift/osde2e"
+    openshift.io/support-url: "https://github.com/openshift/osd-example-operator"
+parameters:
+  - name: OSDE2E_CONFIGS
+    displayName: "OSDE2E Configurations"
+    description: "Configuration string for osde2e (e.g., rosa,sts,int,ad-hoc-image)"
+    required: true
+  - name: TEST_IMAGE
+    displayName: "Test Image"
+    description: "The test image to run"
+    required: true
+  - name: OCM_CLIENT_ID
+    displayName: "OCM Client ID"
+    description: "OCM client ID for authentication"
+    required: false
+  - name: OCM_CLIENT_SECRET
+    displayName: "OCM Client Secret"
+    description: "OCM client secret for authentication"
+    required: false
+  - name: OCM_CCS
+    displayName: "OCM CCS"
+    description: "OCM CCS configuration"
+    required: false
+  - name: AWS_ACCESS_KEY_ID
+    displayName: "AWS Access Key ID"
+    description: "AWS access key ID"
+    required: false
+  - name: AWS_SECRET_ACCESS_KEY
+    displayName: "AWS Secret Access Key"
+    description: "AWS secret access key"
+    required: false
+  - name: CLOUD_PROVIDER_REGION
+    displayName: "Cloud Provider Region"
+    description: "Cloud provider region"
+    required: false
+    value: "us-east-1"
+  - name: GCP_CREDS_JSON
+    displayName: "GCP Credentials JSON"
+    description: "GCP credentials in JSON format"
+    required: false
+  - name: JOBID
+    displayName: "Job ID"
+    description: "Unique identifier for this test run"
+    generate: expression
+    from: "[0-9a-z]{7}"
+  - name: IMAGE_TAG
+    displayName: "Image Tag"
+    description: "Tag for the test image"
+    value: ''
+    required: true
+  - name: LOG_BUCKET
+    displayName: "Log Bucket"
+    description: "S3 bucket for storing logs"
+    value: 'osde2e-logs'
+  - name: USE_EXISTING_CLUSTER
+    displayName: "Use Existing Cluster"
+    description: "Whether to use an existing cluster"
+    value: 'TRUE'
+  - name: CAD_PAGERDUTY_ROUTING_KEY
+    displayName: "PagerDuty Routing Key"
+    description: "PagerDuty routing key for alerts"
+    required: false
+objects:
+  # PersistentVolumeClaim for test workspace
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: osde2e-test-workspace-${JOBID}
+      labels:
+        app: osde2e
+        component: testing
+        job-id: ${JOBID}
+        test-image-tag: ${IMAGE_TAG}
+      annotations:
+        description: "Workspace for OSDE2E test execution and result storage"
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 2Gi
+      storageClassName: gp3-csi
+
+  # ServiceAccount for PipelineRun execution
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: osde2e-pipeline-sa-${JOBID}
+      labels:
+        app: osde2e
+        component: testing
+        job-id: ${JOBID}
+      annotations:
+        description: "Service account for OSDE2E pipeline execution"
+
+  # Role for pipeline execution permissions
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      name: osde2e-pipeline-role-${JOBID}
+      labels:
+        app: osde2e
+        component: testing
+        job-id: ${JOBID}
+    rules:
+    - apiGroups: [""]
+      resources: ["pods", "pods/log", "persistentvolumeclaims"]
+      verbs: ["get", "list", "create", "update", "patch", "delete"]
+    - apiGroups: ["tekton.dev"]
+      resources: ["taskruns", "pipelineruns"]
+      verbs: ["get", "list", "create", "update", "patch", "delete"]
+
+  # RoleBinding for ServiceAccount
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: osde2e-pipeline-rolebinding-${JOBID}
+      labels:
+        app: osde2e
+        component: testing
+        job-id: ${JOBID}
+    subjects:
+    - kind: ServiceAccount
+      name: osde2e-pipeline-sa-${JOBID}
+    roleRef:
+      kind: Role
+      name: osde2e-pipeline-role-${JOBID}
+      apiGroup: rbac.authorization.k8s.io
+
+  # PipelineRun for test execution
+  - apiVersion: tekton.dev/v1
+    kind: PipelineRun
+    metadata:
+      name: osde2e-osd-example-operator-${IMAGE_TAG}-${JOBID}
+      labels:
+        app: osde2e
+        component: testing
+        job-id: ${JOBID}
+        test-image-tag: ${IMAGE_TAG}
+        osde2e-configs: ${OSDE2E_CONFIGS}
+      annotations:
+        # Enable Tekton Results collection
+        results.tekton.dev/record: "true"
+        results.tekton.dev/log: "true"
+        # Additional metadata for observability
+        osde2e.openshift.io/config: ${OSDE2E_CONFIGS}
+        osde2e.openshift.io/test-image: ${TEST_IMAGE}:${IMAGE_TAG}
+        osde2e.openshift.io/region: ${CLOUD_PROVIDER_REGION}
+        osde2e.openshift.io/job-id: ${JOBID}
+        description: "OSDE2E test execution for osd-example-operator"
+    spec:
+      serviceAccountName: osde2e-pipeline-sa-${JOBID}
+      pipelineRef:
+        name: osde2e-test-pipeline
+      params:
+      - name: OSDE2E_CONFIGS
+        value: ${OSDE2E_CONFIGS}
+      - name: TEST_IMAGE
+        value: ${TEST_IMAGE}
+      - name: IMAGE_TAG
+        value: ${IMAGE_TAG}
+      - name: OCM_CLIENT_ID
+        value: ${OCM_CLIENT_ID}
+      - name: OCM_CLIENT_SECRET
+        value: ${OCM_CLIENT_SECRET}
+      - name: AWS_ACCESS_KEY_ID
+        value: ${AWS_ACCESS_KEY_ID}
+      - name: AWS_SECRET_ACCESS_KEY
+        value: ${AWS_SECRET_ACCESS_KEY}
+      - name: CLOUD_PROVIDER_REGION
+        value: ${CLOUD_PROVIDER_REGION}
+      - name: LOG_BUCKET
+        value: ${LOG_BUCKET}
+      - name: USE_EXISTING_CLUSTER
+        value: ${USE_EXISTING_CLUSTER}
+      - name: CAD_PAGERDUTY_ROUTING_KEY
+        value: ${CAD_PAGERDUTY_ROUTING_KEY}
+      workspaces:
+      - name: test-workspace
+        persistentVolumeClaim:
+          claimName: osde2e-test-workspace-${JOBID}
+      # Timeout for the entire pipeline (3 hours like the original Job)
+      timeouts:
+        pipeline: "3h0m0s"
+        tasks: "2h45m0s"
+        finally: "15m0s"

--- a/test/e2e/osde2e-pipeline.yml
+++ b/test/e2e/osde2e-pipeline.yml
@@ -1,0 +1,162 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: osde2e-test-pipeline
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.17.0"
+    tekton.dev/categories: Testing
+    tekton.dev/tags: osde2e,testing,e2e,pipeline
+    tekton.dev/displayName: "OSDE2E Test Pipeline"
+    tekton.dev/platforms: "linux/amd64"
+spec:
+  description: >-
+    This pipeline orchestrates osde2e testing with comprehensive result collection
+    for Tekton Results observability. It runs tests, collects logs and JUnit results,
+    and provides structured output for monitoring and analysis.
+
+  params:
+  - name: OSDE2E_CONFIGS
+    type: string
+    description: Configuration string for osde2e (e.g., "rosa,sts,int,ad-hoc-image")
+  - name: TEST_IMAGE
+    type: string
+    description: The test image to run
+  - name: IMAGE_TAG
+    type: string
+    description: Tag for the test image
+    default: "latest"
+  - name: OCM_CLIENT_ID
+    type: string
+    description: OCM client ID for authentication
+    default: ""
+  - name: OCM_CLIENT_SECRET
+    type: string
+    description: OCM client secret for authentication
+    default: ""
+  - name: AWS_ACCESS_KEY_ID
+    type: string
+    description: AWS access key ID
+    default: ""
+  - name: AWS_SECRET_ACCESS_KEY
+    type: string
+    description: AWS secret access key
+    default: ""
+  - name: CLOUD_PROVIDER_REGION
+    type: string
+    description: Cloud provider region
+    default: "us-east-1"
+  - name: LOG_BUCKET
+    type: string
+    description: S3 bucket for logs
+    default: "osde2e-logs"
+  - name: USE_EXISTING_CLUSTER
+    type: string
+    description: Whether to use existing cluster
+    default: "TRUE"
+  - name: CAD_PAGERDUTY_ROUTING_KEY
+    type: string
+    description: PagerDuty routing key for alerts
+    default: ""
+
+  workspaces:
+  - name: test-workspace
+    description: Shared workspace for test execution and result storage
+
+  results:
+  - name: final-test-status
+    description: Final test status from the pipeline
+    value: $(tasks.osde2e-test.results.test-status)
+  - name: test-summary
+    description: Test execution summary
+    value: $(tasks.osde2e-test.results.test-summary)
+
+  tasks:
+  - name: osde2e-test
+    taskRef:
+      name: osde2e-test-task
+    params:
+    - name: OSDE2E_CONFIGS
+      value: $(params.OSDE2E_CONFIGS)
+    - name: TEST_IMAGE
+      value: $(params.TEST_IMAGE)
+    - name: IMAGE_TAG
+      value: $(params.IMAGE_TAG)
+    - name: OCM_CLIENT_ID
+      value: $(params.OCM_CLIENT_ID)
+    - name: OCM_CLIENT_SECRET
+      value: $(params.OCM_CLIENT_SECRET)
+    - name: AWS_ACCESS_KEY_ID
+      value: $(params.AWS_ACCESS_KEY_ID)
+    - name: AWS_SECRET_ACCESS_KEY
+      value: $(params.AWS_SECRET_ACCESS_KEY)
+    - name: CLOUD_PROVIDER_REGION
+      value: $(params.CLOUD_PROVIDER_REGION)
+    - name: LOG_BUCKET
+      value: $(params.LOG_BUCKET)
+    - name: USE_EXISTING_CLUSTER
+      value: $(params.USE_EXISTING_CLUSTER)
+    - name: CAD_PAGERDUTY_ROUTING_KEY
+      value: $(params.CAD_PAGERDUTY_ROUTING_KEY)
+    workspaces:
+    - name: test-results
+      workspace: test-workspace
+
+  finally:
+  - name: cleanup-and-report
+    params:
+    - name: TEST_STATUS
+      value: $(tasks.osde2e-test.results.test-status)
+    - name: OSDE2E_CONFIGS
+      value: $(params.OSDE2E_CONFIGS)
+    taskSpec:
+      params:
+      - name: TEST_STATUS
+      - name: OSDE2E_CONFIGS
+      workspaces:
+      - name: test-results
+        mountPath: /workspace/test-results
+      steps:
+      - name: final-report
+        image: quay.io/redhat-services-prod/osde2e-cicada-tenant/osde2e:latest
+        script: |
+          #!/bin/bash
+          set -euo pipefail
+
+          echo "=== Final Pipeline Report ==="
+          echo "Pipeline execution completed"
+          echo "Test Status: $(params.TEST_STATUS)"
+          echo "Configuration: $(params.OSDE2E_CONFIGS)"
+          echo "Timestamp: $(date -Iseconds)"
+
+          # Log final status to workspace
+          {
+            echo "=== Pipeline Final Report ==="
+            echo "Execution completed at: $(date -Iseconds)"
+            echo "Final Status: $(params.TEST_STATUS)"
+            echo "Configuration: $(params.OSDE2E_CONFIGS)"
+            echo ""
+            echo "Available result files:"
+            find /workspace/test-results -type f -name "*.log" -o -name "*.xml" | sort
+          } >> /workspace/test-results/logs/pipeline-final-report.log
+
+          if [ "$(params.TEST_STATUS)" = "PASS" ]; then
+            echo "✅ Pipeline completed successfully"
+            exit 0
+          else
+            echo "❌ Pipeline completed with test failures"
+            # Don't fail the finally task, just report
+            exit 0
+          fi
+        securityContext:
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+          seccompProfile:
+            type: RuntimeDefault
+    workspaces:
+    - name: test-results
+      workspace: test-workspace
+

--- a/test/e2e/osde2e-tekton-task.yml
+++ b/test/e2e/osde2e-tekton-task.yml
@@ -1,0 +1,332 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: osde2e-test-task
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.17.0"
+    tekton.dev/categories: Testing
+    tekton.dev/tags: osde2e,testing,e2e
+    tekton.dev/displayName: "OSDE2E Test Task"
+    tekton.dev/platforms: "linux/amd64"
+spec:
+  description: >-
+    This task runs osde2e tests and collects results for Tekton Results observability.
+    It captures stdout logs, JUnit XML results, and test status for pipeline observability.
+
+  params:
+  - name: OSDE2E_CONFIGS
+    type: string
+    description: Configuration string for osde2e (e.g., "rosa,sts,int,ad-hoc-image")
+  - name: TEST_IMAGE
+    type: string
+    description: The test image to run
+  - name: IMAGE_TAG
+    type: string
+    description: Tag for the test image
+    default: "latest"
+  - name: OCM_CLIENT_ID
+    type: string
+    description: OCM client ID for authentication
+    default: ""
+  - name: OCM_CLIENT_SECRET
+    type: string
+    description: OCM client secret for authentication
+    default: ""
+  - name: AWS_ACCESS_KEY_ID
+    type: string
+    description: AWS access key ID
+    default: ""
+  - name: AWS_SECRET_ACCESS_KEY
+    type: string
+    description: AWS secret access key
+    default: ""
+  - name: CLOUD_PROVIDER_REGION
+    type: string
+    description: Cloud provider region
+    default: "us-east-1"
+  - name: LOG_BUCKET
+    type: string
+    description: S3 bucket for logs
+    default: "osde2e-logs"
+  - name: USE_EXISTING_CLUSTER
+    type: string
+    description: Whether to use existing cluster
+    default: "TRUE"
+  - name: CAD_PAGERDUTY_ROUTING_KEY
+    type: string
+    description: PagerDuty routing key for alerts
+    default: ""
+
+  results:
+  - name: test-results
+    description: JUnit XML test results
+  - name: test-logs
+    description: Test execution logs
+  - name: test-status
+    description: Overall test status (PASS/FAIL)
+  - name: test-summary
+    description: Test execution summary
+
+  workspaces:
+  - name: test-results
+    description: Workspace for storing test results and logs
+    mountPath: /workspace/test-results
+
+  steps:
+  - name: fix-workspace-permissions
+    image: registry.access.redhat.com/ubi8/ubi-minimal:latest
+    script: |
+      #!/bin/bash
+      set -euo pipefail
+
+      echo "Fixing workspace permissions..."
+
+      # Create directories with proper permissions
+      mkdir -p $(workspaces.test-results.path)/junit
+      mkdir -p $(workspaces.test-results.path)/logs
+      mkdir -p $(workspaces.test-results.path)/reports
+      mkdir -p $(workspaces.test-results.path)/shared
+
+      # Set permissions for non-root user (osde2e runs as UID 1001)
+      chown -R 1001:0 $(workspaces.test-results.path)
+      chmod -R 775 $(workspaces.test-results.path)
+
+      echo "Workspace permissions fixed successfully"
+
+    securityContext:
+      runAsUser: 0  # Run as root to fix permissions
+      allowPrivilegeEscalation: true
+
+  - name: setup-test-environment
+    image: quay.io/redhat-services-prod/osde2e-cicada-tenant/osde2e:latest
+    script: |
+      #!/bin/bash
+      set -euo pipefail
+
+      echo "Setting up test environment..."
+
+      # Verify directories exist and are writable
+      ls -la $(workspaces.test-results.path)/
+
+      # Log environment information
+      echo "=== Test Environment Setup ===" | tee $(workspaces.test-results.path)/logs/setup.log
+      echo "OSDE2E_CONFIGS: $(params.OSDE2E_CONFIGS)" | tee -a $(workspaces.test-results.path)/logs/setup.log
+      echo "TEST_IMAGE: $(params.TEST_IMAGE):$(params.IMAGE_TAG)" | tee -a $(workspaces.test-results.path)/logs/setup.log
+      echo "CLOUD_PROVIDER_REGION: $(params.CLOUD_PROVIDER_REGION)" | tee -a $(workspaces.test-results.path)/logs/setup.log
+      echo "USE_EXISTING_CLUSTER: $(params.USE_EXISTING_CLUSTER)" | tee -a $(workspaces.test-results.path)/logs/setup.log
+      echo "Setup completed successfully" | tee -a $(workspaces.test-results.path)/logs/setup.log
+
+    securityContext:
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+      seccompProfile:
+        type: RuntimeDefault
+
+  - name: run-osde2e-tests
+    image: quay.io/redhat-services-prod/osde2e-cicada-tenant/osde2e:latest
+    script: |
+      #!/bin/bash
+      set -euo pipefail
+
+      echo "Starting osde2e test execution..."
+
+      # Set test start time
+      TEST_START_TIME=$(date -Iseconds)
+      echo "Test started at: $TEST_START_TIME" | tee $(workspaces.test-results.path)/logs/test-execution.log
+
+      # Run osde2e tests with enhanced logging and result collection
+      TEST_EXIT_CODE=0
+      /osde2e test \
+        --only-health-check-nodes \
+        --skip-destroy-cluster \
+        --skip-must-gather \
+        --configs $(params.OSDE2E_CONFIGS) \
+        2>&1 | tee $(workspaces.test-results.path)/logs/osde2e-full.log || TEST_EXIT_CODE=$?
+
+      # Set test end time
+      TEST_END_TIME=$(date -Iseconds)
+      echo "Test completed at: $TEST_END_TIME" | tee -a $(workspaces.test-results.path)/logs/test-execution.log
+      echo "Test exit code: $TEST_EXIT_CODE" | tee -a $(workspaces.test-results.path)/logs/test-execution.log
+
+      # Determine test status
+      if [ $TEST_EXIT_CODE -eq 0 ]; then
+        echo "PASS" > $(results.test-status.path)
+        echo "✅ All tests passed" | tee -a $(workspaces.test-results.path)/logs/test-execution.log
+      else
+        echo "FAIL" > $(results.test-status.path)
+        echo "❌ Tests failed with exit code: $TEST_EXIT_CODE" | tee -a $(workspaces.test-results.path)/logs/test-execution.log
+      fi
+
+      # Create test summary
+      echo "=== Test Execution Summary ===" > $(workspaces.test-results.path)/logs/summary.log
+      echo "Start Time: $TEST_START_TIME" >> $(workspaces.test-results.path)/logs/summary.log
+      echo "End Time: $TEST_END_TIME" >> $(workspaces.test-results.path)/logs/summary.log
+      echo "Exit Code: $TEST_EXIT_CODE" >> $(workspaces.test-results.path)/logs/summary.log
+      echo "Status: $(cat $(results.test-status.path))" >> $(workspaces.test-results.path)/logs/summary.log
+      echo "Config: $(params.OSDE2E_CONFIGS)" >> $(workspaces.test-results.path)/logs/summary.log
+
+      # Copy summary to result
+      cp $(workspaces.test-results.path)/logs/summary.log $(results.test-summary.path)
+
+      # Exit with the original test exit code to maintain pipeline behavior
+      exit $TEST_EXIT_CODE
+
+    env:
+    # Test configuration
+    - name: AD_HOC_TEST_IMAGES
+      value: "$(params.TEST_IMAGE):$(params.IMAGE_TAG)"
+    - name: CLOUD_PROVIDER_REGION
+      value: "$(params.CLOUD_PROVIDER_REGION)"
+    - name: LOG_BUCKET
+      value: "$(params.LOG_BUCKET)"
+    - name: USE_EXISTING_CLUSTER
+      value: "$(params.USE_EXISTING_CLUSTER)"
+    - name: CAD_PAGERDUTY_ROUTING_KEY
+      value: "$(params.CAD_PAGERDUTY_ROUTING_KEY)"
+    # osde2e output configuration
+    - name: REPORT_DIR
+      value: "$(workspaces.test-results.path)/reports"
+    - name: SHARED_DIR
+      value: "$(workspaces.test-results.path)/shared"
+    # Credentials from Secret and Parameters (Secret takes precedence)
+    - name: OCM_CLIENT_ID
+      valueFrom:
+        secretKeyRef:
+          name: osde2e-credentials
+          key: OCM_CLIENT_ID
+          optional: true
+    - name: OCM_CLIENT_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: osde2e-credentials
+          key: OCM_CLIENT_SECRET
+          optional: true
+    - name: AWS_ACCESS_KEY_ID
+      valueFrom:
+        secretKeyRef:
+          name: osde2e-credentials
+          key: AWS_ACCESS_KEY_ID
+          optional: true
+    - name: AWS_SECRET_ACCESS_KEY
+      valueFrom:
+        secretKeyRef:
+          name: osde2e-credentials
+          key: AWS_SECRET_ACCESS_KEY
+          optional: true
+    # Fallback to parameters if secret is not available
+    - name: OCM_CLIENT_ID_PARAM
+      value: "$(params.OCM_CLIENT_ID)"
+    - name: OCM_CLIENT_SECRET_PARAM
+      value: "$(params.OCM_CLIENT_SECRET)"
+    - name: AWS_ACCESS_KEY_ID_PARAM
+      value: "$(params.AWS_ACCESS_KEY_ID)"
+    - name: AWS_SECRET_ACCESS_KEY_PARAM
+      value: "$(params.AWS_SECRET_ACCESS_KEY)"
+
+    securityContext:
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+      seccompProfile:
+        type: RuntimeDefault
+
+  - name: collect-test-results
+    image: quay.io/redhat-services-prod/osde2e-cicada-tenant/osde2e:latest
+    script: |
+      #!/bin/bash
+      set -euo pipefail
+
+      echo "Collecting and processing test results..."
+
+      # Process JUnit XML results from osde2e REPORT_DIR
+      JUNIT_FOUND=false
+
+      # Check for JUnit XML in reports directory (osde2e default location)
+      if [ -d "$(workspaces.test-results.path)/reports" ]; then
+        echo "Searching for JUnit XML files in reports directory..."
+        find $(workspaces.test-results.path)/reports -name "*.xml" -type f > /tmp/junit_files.txt 2>/dev/null || true
+
+        if [ -s /tmp/junit_files.txt ]; then
+          echo "Found JUnit XML files, merging results..."
+          cat $(cat /tmp/junit_files.txt) > $(results.test-results.path) 2>/dev/null && JUNIT_FOUND=true
+
+          # Log JUnit summary
+          echo "=== JUnit Results Summary ===" >> $(workspaces.test-results.path)/logs/summary.log
+          echo "JUnit XML files found:" >> $(workspaces.test-results.path)/logs/summary.log
+          cat /tmp/junit_files.txt >> $(workspaces.test-results.path)/logs/summary.log
+        fi
+      fi
+
+      # Also check for junit.xml in the main reports directory (common osde2e pattern)
+      if [ -f "$(workspaces.test-results.path)/reports/junit.xml" ]; then
+        echo "Found junit.xml in reports directory"
+        cp $(workspaces.test-results.path)/reports/junit.xml $(results.test-results.path)
+        JUNIT_FOUND=true
+      fi
+
+      # If no JUnit results found, create empty result
+      if [ "$JUNIT_FOUND" = "false" ]; then
+        echo "No JUnit XML results found, creating empty result"
+        echo '<?xml version="1.0" encoding="UTF-8"?><testsuite name="osde2e" tests="0" failures="0" errors="0" time="0"/>' > $(results.test-results.path)
+        echo "No JUnit XML files found" >> $(workspaces.test-results.path)/logs/summary.log
+      fi
+
+      # Consolidate all logs
+      echo "Consolidating test logs..."
+      {
+        echo "=== OSDE2E Test Execution Logs ==="
+        echo "Generated at: $(date -Iseconds)"
+        echo ""
+
+        if [ -f "$(workspaces.test-results.path)/logs/setup.log" ]; then
+          echo "=== Setup Logs ==="
+          cat $(workspaces.test-results.path)/logs/setup.log
+          echo ""
+        fi
+
+        if [ -f "$(workspaces.test-results.path)/logs/test-execution.log" ]; then
+          echo "=== Test Execution Summary ==="
+          cat $(workspaces.test-results.path)/logs/test-execution.log
+          echo ""
+        fi
+
+        if [ -f "$(workspaces.test-results.path)/logs/osde2e-full.log" ]; then
+          echo "=== Full OSDE2E Output ==="
+          cat $(workspaces.test-results.path)/logs/osde2e-full.log
+        fi
+
+        # Include osde2e generated logs from REPORT_DIR
+        if [ -d "$(workspaces.test-results.path)/reports" ]; then
+          echo ""
+          echo "=== OSDE2E Generated Files ==="
+          find $(workspaces.test-results.path)/reports -type f -name "*.log" 2>/dev/null | while read logfile; do
+            if [ -f "$logfile" ]; then
+              echo ""
+              echo "=== $(basename $logfile) ==="
+              cat "$logfile" 2>/dev/null || echo "Could not read $logfile"
+            fi
+          done
+
+          # Include test_output.log if it exists (osde2e default)
+          if [ -f "$(workspaces.test-results.path)/reports/test_output.log" ]; then
+            echo ""
+            echo "=== OSDE2E Test Output Log ==="
+            cat $(workspaces.test-results.path)/reports/test_output.log
+          fi
+        fi
+      } > $(results.test-logs.path)
+
+      echo "Test result collection completed successfully"
+
+    securityContext:
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+      seccompProfile:
+        type: RuntimeDefault


### PR DESCRIPTION
This enables structured test results collection via Tekton Results.
Results include: test-status, test-logs, test-summary, and JUnit XML.

**Changes:**

- Add osde2e-tekton-task.yml: Multi-step Task with Results output
- Add osde2e-pipeline.yml: Pipeline orchestration
- Add e2e-tekton-template.yml: Template for app-interface integration
- Add TEKTON-RESULTS-README.md: Integration guide


[SDCICD-1672](https://issues.redhat.com//browse/SDCICD-1672)

Co-Authored-By: cursor [cursor@cursor.sh](mailto:cursor@cursor.sh)
