### PR TITLE
rm --skip-destroy-cluster for testing

### DIFF
--- a/test/e2e/e2e-template.yml
+++ b/test/e2e/e2e-template.yml
@@ -60,7 +60,6 @@ objects:
               args:
                 - test
                 - --only-health-check-nodes
-                - --skip-destroy-cluster
                 - --skip-must-gather
                 - --log-analysis-enable
                 - --configs


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Modified test configuration to ensure test cluster resources are automatically destroyed after test runs complete, improving resource efficiency and preventing accumulation of orphaned infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->