### PR TITLE
update api to use template.openshift.io/v1 form

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 parameters:
 - name: CHANNEL


### PR DESCRIPTION
Starting with oc 4.17, templates must use `apiVersion: template.openshift.io/v1` for oc process --local to work. The `apiVersion: v1` shorthand is no longer recognized in the local scheme. This affects any oc build from 4.17 onward:
https://github.com/openshift/oc/pull/1775

The fix was attempted in https://github.com/openshift/oc/pull/1805 but it was never merged